### PR TITLE
修复 phoneHash 不通过校验的问题

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -10,9 +10,11 @@ function phoneHash(phone, async) {
     return phoneHashSync(saltRounds, minor)
     function phoneHashSync (saltRounds, minor) {
         var salt = bcrypt.genSaltSync(saltRounds, minor)
-        var hashstr = crypto.createHash('sha256').update(phone + salt).digest('base64');
-        var salt2 = bcrypt.genSaltSync(saltRounds, minor)
-        var hash = bcrypt.hashSync(hashstr, salt2);
+        var hashstr = crypto.createHash('sha256').update(phone + salt, 'utf-8').digest('base64');
+        var buff = new Buffer(hashstr);
+        var phoneBase64 = buff.toString('base64');
+        var salt2 = bcrypt.genSaltSync(saltRounds, minor);
+        var hash = bcrypt.hashSync(phoneBase64, salt2);
         return {salt: salt, hash: hash}
     }
     function  phoneHashASync(saltRounds, minor) {
@@ -21,8 +23,10 @@ function phoneHash(phone, async) {
                 if (!err) {
                     return bcrypt.genSalt(saltRounds, minor, function(err, salt2) {
                         if (!err) {
-                            var hashstr = crypto.createHash('sha256').update(phone + salt).digest('base64');
-                            return bcrypt.hash(hashstr, salt2, function(err, hash) {
+                            var hashstr = crypto.createHash('sha256').update(phone + salt, 'utf-8').digest('hex');
+                            let buff = new Buffer(hashstr);
+                            let phoneBase64 = buff.toString('base64');
+                            return bcrypt.hash(phoneBase64, salt2, function(err, hash) {
                                 if (!err) {
                                     return resolve({salt: salt, hash: hash})
                                 }


### PR DESCRIPTION
修复 phoneHash 不通过校验的问题

之前没做 base64 这部

```
public JSONObject phoneHash(String phone) throws CertException {
        String salt = BCrypt.gensalt();
        String pHash = SHA.SHA256(phone + salt);
        String phoneBase64 = null;

        try {
            byte[] hash = pHash.getBytes("UTF-8");
            phoneBase64 = new String(Base64Coder.encode(hash));
        } catch (UnsupportedEncodingException var8) {
            throw new CertException(1003, var8);
        }

        String phoneHash = BCrypt.hashpw(phoneBase64, BCrypt.gensalt());
        StringBuffer strB = new StringBuffer();
        strB.append("{\"phone\":\"");
        strB.append(phoneHash);
        strB.append("\",\"salt\":\"");
        strB.append(salt);
        strB.append("\"}");
        JSONObject jo = JSONObject.fromObject(strB.toString());
        return jo;
    }
```